### PR TITLE
adds conditional rendering of personal page to fix #12 bug

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,20 @@ import usersData from "./assets/data/users.json";
 
 function App() {
   const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   const loadUsers = () => {
     setUsers(usersData);
+    setLoading(false);
   };
 
   useEffect(() => {
     loadUsers();
   }, []);
+
+  const LoadingComponent = () => {
+    return <div>Loading...</div>;
+  };  
 
   const appRoutes = createBrowserRouter([
     {
@@ -25,7 +31,7 @@ function App() {
         },
         {
           path: "/:userId",
-          element: <PersonalPage users={users} />,
+          element: !loading ? <PersonalPage users={users} /> : <LoadingComponent />,
         },
       ],
     },

--- a/src/components/PersonalPage/Links/UserLinks.jsx
+++ b/src/components/PersonalPage/Links/UserLinks.jsx
@@ -50,7 +50,7 @@ const UserLinks = ({ links }) => {
 };
 
 UserLinks.propTypes = {
-  links: PropTypes.array,
+  links: PropTypes.object,
 };
 
 export default UserLinks;

--- a/src/components/PersonalPage/PersonalPage.jsx
+++ b/src/components/PersonalPage/PersonalPage.jsx
@@ -8,7 +8,7 @@ import UserLinks from "./Links/UserLinks";
 const PersonalPage = ({ users }) => {
   let { userId } = useParams();
   const user = users.find((user) => user.name === userId);
-  console.log(user);
+  console.log(users);
   const links = user?.links;
 
   return (


### PR DESCRIPTION
New branch to work on fixing #12 bug. Closes #12

Aebel's suggestion worked! The main problem was personal page rendering before `users` state can be set, resulting in `users` being undefined. The solution was to conditionally render personal page only once the `users` state has been set.

The small change in `UserLinks` corrects the proptype so that the warning message about it doesn't show up anymore.